### PR TITLE
feat: add chat API route using ai SDK

### DIFF
--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -1,0 +1,14 @@
+import { type CoreMessage, streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+export async function POST(req: Request) {
+  const { messages }: { messages: CoreMessage[] } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-4o-mini"),
+    system: "You are a helpful assistant.",
+    messages,
+  });
+
+  return result.toDataStreamResponse();
+}

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.4.6"
+    "next": "15.4.6",
+    "ai": "^3.4.32",
+    "@ai-sdk/openai": "^0.0.66"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- add ai SDK and OpenAI dependencies
- implement streaming chat API route

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a96c6e70e48332b8e7d04f0e4effc2